### PR TITLE
add email to syllabus

### DIFF
--- a/docs/cs155/index.md
+++ b/docs/cs155/index.md
@@ -10,6 +10,8 @@ the central ideas, practices, and day to day usage of software version
 control using Git. Basic client side usage such as committing,
 branching, merging, and pull-requests will be explored. COREQ: CS153.
 
+Instructor Email: shanepanter@boisestate.edu
+
 ## Course Learning Outcomes
 
 By the end of this course the student should have achieved the following


### PR DESCRIPTION
Previously the instructor email was not present anywhere in the syllabus so I added it to the top of the document

## Pull Request

When I reached out via email yesterday I couldn't find the instructor email anywhere in the syllabus, so I thought I should probably add it to the top of the document. Maybe it could be added to the Communication Policy section also.

## Extra Credit

If you want extra credit you need to put your BSU email address below so I can update your grade in
canvas. I am not always able to determine who you are based on your github username alone.

benjaminblodgett311@u.boisestate.edu
