### PR TITLE
Update syllabus-boiler.md

### DIFF
--- a/parts/syllabus-boiler.md
+++ b/parts/syllabus-boiler.md
@@ -79,7 +79,7 @@ are responsible for all verbal announcements or updates given during class.
 ## Late Work Policy
 
 All homework assignments can be submitted up to **2 days late with no penalty**.  After the 2 day
-grade period no further submissions will be accepted unless prior arrangements have been made before
+grace period no further submissions will be accepted unless prior arrangements have been made before
 the original due date. No work or extra credit will be accepted after the **last day of course
 instruction**, the semester has to end at some point so plan accordingly. Work submitted 1 second
 late is treated the same as work submitted 1 day late. You can find the last day of course


### PR DESCRIPTION
Fixed typo in the Late Work Policy section. Sentence read "After the 2 day grade period", but now reads "after the 2 day graCe period".

## Pull Request

Fixed typo in the Late Work Policy section. Sentence read "After the 2 day grade period", but now reads "after the 2 day graCe period".

## Extra Credit

If you want extra credit you need to put your BSU email address below so I can update your grade in
canvas. I am not always able to determine who you are based on your github username alone.

CodySwinnerton@u.boisestate.edu
